### PR TITLE
Simplify schema error formatting

### DIFF
--- a/src/schema_error.rs
+++ b/src/schema_error.rs
@@ -4,439 +4,152 @@ pub(crate) struct SchemaError<'a>(pub(crate) &'a ValidationError<'a>);
 
 impl Display for SchemaError<'_> {
   fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-    f.write_str(&Self::format_validation_error(self.0))
-  }
-}
-
-impl SchemaError<'_> {
-  fn array_length(value: &Value) -> Option<usize> {
-    value.as_array().map(Vec::len)
-  }
-
-  fn decode_segment(segment: &str) -> String {
-    let mut decoded = String::with_capacity(segment.len());
-
-    let mut chars = segment.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-      if ch == '~' {
-        match chars.next() {
-          Some('0') | None => decoded.push('~'),
-          Some('1') => decoded.push('/'),
-          Some(other) => {
-            decoded.push('~');
-            decoded.push(other);
-          }
-        }
-      } else {
-        decoded.push(ch);
-      }
-    }
-
-    decoded
-  }
-
-  fn describe_value(value: &Value) -> String {
-    match value {
-      Value::Null => "null".to_string(),
-      Value::Bool(boolean) => format!("boolean {boolean}"),
-      Value::Number(number) => {
-        if number.is_i64() || number.is_u64() {
-          format!("integer {number}")
-        } else {
-          format!("number {number}")
-        }
-      }
-      Value::String(string) => format!("string \"{string}\""),
-      Value::Array(values) => format!("array of length {}", values.len()),
-      Value::Object(_) => "object".to_string(),
-    }
-  }
-
-  fn dotted_path(pointer: &str) -> String {
-    pointer
+    let path = self
+      .0
+      .instance_path()
+      .as_str()
       .trim_start_matches('/')
       .split('/')
       .filter(|segment| !segment.is_empty())
-      .map(Self::decode_segment)
+      .map(|segment| segment.replace("~1", "/").replace("~0", "~"))
       .collect::<Vec<_>>()
-      .join(".")
-  }
+      .join(".");
 
-  fn expected_types(kind: &TypeKind) -> String {
-    match kind {
-      TypeKind::Single(type_) => type_.to_string(),
-      TypeKind::Multiple(types) => {
-        let mut names = types
-          .iter()
-          .map(|type_| type_.to_string())
-          .collect::<Vec<_>>();
-
-        names.sort();
-
-        if names.len() <= 1 {
-          names.join("")
-        } else if names.len() == 2 {
-          format!("{} or {}", names[0], names[1])
-        } else {
-          let last = names.pop().unwrap_or_default();
-          format!("{}, or {last}", names.join(", "))
-        }
-      }
-    }
-  }
-
-  fn format_enum_options(options: &Value) -> String {
-    match options {
-      Value::Array(values) => values
-        .iter()
-        .map(Self::format_literal)
-        .collect::<Vec<_>>()
-        .join(", "),
-      _ => options.to_string(),
-    }
-  }
-
-  fn format_literal(value: &Value) -> String {
-    match value {
-      Value::Null => "null".to_string(),
-      Value::Bool(boolean) => boolean.to_string(),
-      Value::Number(number) => number.to_string(),
-      Value::String(string) => format!("\"{string}\""),
-      Value::Array(_) | Value::Object(_) => value.to_string(),
-    }
-  }
-
-  fn format_setting(path: &str) -> String {
-    if path.is_empty() {
+    let target = if path.is_empty() {
       "value".to_string()
     } else {
       format!("`{path}`")
-    }
-  }
+    };
 
-  fn format_validation_error(error: &ValidationError) -> String {
-    let path = Self::dotted_path(error.instance_path().as_str());
-
-    let target = Self::format_setting(&path);
-
-    let message = match error.kind() {
+    let message = match self.0.kind() {
       ValidationErrorKind::AdditionalItems { limit } => {
-        let count = Self::array_length(error.instance().as_ref());
+        let count = self.0.instance().as_array().map(Vec::len);
 
-        match count {
-          Some(len) => {
-            format!("{target} allows at most {limit} items, found {len}")
-          }
-          None => format!("{target} allows at most {limit} items"),
-        }
+        count.map_or_else(
+          || format!("{target} allows at most {limit} items"),
+          |count| {
+            format!("{target} allows at most {limit} items, found {count}")
+          },
+        )
       }
       ValidationErrorKind::AdditionalProperties { unexpected } => {
-        let setting_path = unexpected
-          .first()
-          .map(|property| Self::join_path_segments(&path, property))
-          .filter(|setting| !setting.is_empty())
-          .unwrap_or_else(|| path.clone());
+        let setting = unexpected.first().map_or_else(
+          || target.clone(),
+          |property| {
+            let path = if path.is_empty() {
+              property.clone()
+            } else {
+              format!("{path}.{property}")
+            };
 
-        let setting = Self::format_setting(&setting_path);
+            format!("`{path}`")
+          },
+        );
 
         format!("unknown setting {setting}")
       }
-      ValidationErrorKind::AnyOf { context } => {
-        format!(
-          "{target} does not match any allowed schema in anyOf{}",
-          Self::summarize_schema_context(context)
-            .map(|msg| format!(": {msg}"))
-            .unwrap_or_default()
-        )
-      }
-      ValidationErrorKind::BacktrackLimitExceeded { error } => {
-        format!("regex backtracking limit exceeded: {error}")
-      }
-      ValidationErrorKind::Constant { expected_value } => {
-        format!(
-          "{target} must equal {}",
-          Self::format_literal(expected_value)
-        )
-      }
-      ValidationErrorKind::Contains => {
-        format!("{target} must contain at least one item matching the schema")
-      }
-      ValidationErrorKind::ContentEncoding { content_encoding } => {
-        format!("{target} is not valid {content_encoding} content encoding")
-      }
-      ValidationErrorKind::ContentMediaType { content_media_type } => {
-        format!(
-          "{target} is not compliant with media type {content_media_type}"
-        )
-      }
-      ValidationErrorKind::Custom { message } => {
-        format!("{target}: {message}")
-      }
-      ValidationErrorKind::Required { property } => {
-        format!(
-          "missing required setting {}",
-          Self::format_setting(&Self::join_path_segments(
-            &path,
-            &Self::value_to_property(property)
-          ))
-        )
-      }
-      ValidationErrorKind::Type { kind } => {
-        format!(
-          "expected {} for {target}, got {}",
-          Self::expected_types(kind),
-          Self::describe_value(error.instance().as_ref())
-        )
-      }
       ValidationErrorKind::Enum { options } => {
-        format!(
-          "{target} must be one of: {}",
-          Self::format_enum_options(options)
-        )
-      }
-      ValidationErrorKind::ExclusiveMaximum { limit } => {
-        format!(
-          "expected a value less than {limit} for {target}, got {}",
-          Self::describe_value(error.instance().as_ref())
-        )
-      }
-      ValidationErrorKind::ExclusiveMinimum { limit } => {
-        format!(
-          "expected a value greater than {limit} for {target}, got {}",
-          Self::describe_value(error.instance().as_ref())
-        )
-      }
-      ValidationErrorKind::FalseSchema => {
-        format!("no values are allowed for {target}")
-      }
-      ValidationErrorKind::Format { format } => {
-        format!("{target} is not a valid {format}")
-      }
-      ValidationErrorKind::FromUtf8 { error } => {
-        format!("invalid utf-8 data for {target}: {error}")
-      }
-      ValidationErrorKind::MaxItems { limit } => {
-        let count = Self::array_length(error.instance().as_ref());
-
-        match count {
-          Some(len) => {
-            format!("{target} allows at most {limit} items, found {len}")
-          }
-          None => format!("{target} allows at most {limit} items"),
-        }
-      }
-      ValidationErrorKind::Maximum { limit } => {
-        format!(
-          "expected a value no greater than {limit} for {target}, got {}",
-          Self::describe_value(error.instance().as_ref())
-        )
-      }
-      ValidationErrorKind::MaxLength { limit } => {
-        let length = Self::string_length(error.instance().as_ref());
-
-        match length {
-          Some(len) => format!(
-            "{target} must be at most {limit} characters long, found {len}"
-          ),
-          None => format!("{target} must be at most {limit} characters long"),
-        }
-      }
-      ValidationErrorKind::MaxProperties { limit } => {
-        let count = Self::object_length(error.instance().as_ref());
-
-        match count {
-          Some(len) => {
-            format!("{target} allows at most {limit} properties, found {len}")
-          }
-          None => format!("{target} allows at most {limit} properties"),
-        }
-      }
-      ValidationErrorKind::MinItems { limit } => {
-        let count = Self::array_length(error.instance().as_ref());
-
-        match count {
-          Some(len) => {
-            format!("{target} must contain at least {limit} items, found {len}")
-          }
-          None => format!("{target} must contain at least {limit} items"),
-        }
-      }
-      ValidationErrorKind::Minimum { limit } => {
-        let actual = Self::describe_value(error.instance().as_ref());
-
-        format!(
-          "expected a value no less than {limit} for {target}, got {actual}"
-        )
-      }
-      ValidationErrorKind::MinLength { limit } => {
-        let length = Self::string_length(error.instance().as_ref());
-
-        match length {
-          Some(len) => format!(
-            "{target} must be at least {limit} characters long, found {len}"
-          ),
-          None => format!("{target} must be at least {limit} characters long"),
-        }
-      }
-      ValidationErrorKind::MinProperties { limit } => {
-        let count = Self::object_length(error.instance().as_ref());
-
-        match count {
-          Some(len) => format!(
-            "{target} must contain at least {limit} properties, found {len}"
-          ),
-          None => format!("{target} must contain at least {limit} properties"),
-        }
-      }
-      ValidationErrorKind::MultipleOf { multiple_of } => {
-        format!(
-          "expected a multiple of {multiple_of} for {target}, got {}",
-          Self::describe_value(error.instance().as_ref())
-        )
-      }
-      ValidationErrorKind::Not { .. } => {
-        format!("{target} must not match the disallowed schema")
-      }
-      ValidationErrorKind::OneOfMultipleValid { context } => {
-        let matched = Self::matched_schema_indexes(context);
-
-        let base = if matched.is_empty() {
-          format!("{target} matches multiple schemas in oneOf")
-        } else {
-          format!(
-            "{target} matches multiple schemas in oneOf (schemas {} matched)",
-            matched
-              .into_iter()
-              .map(|idx| idx.to_string())
+        let options = options.as_array().map_or_else(
+          || options.to_string(),
+          |options| {
+            options
+              .iter()
+              .map(|value| match value {
+                Value::Null => "null".to_string(),
+                Value::Bool(value) => value.to_string(),
+                Value::Number(value) => value.to_string(),
+                Value::String(value) => format!("\"{value}\""),
+                Value::Array(_) | Value::Object(_) => value.to_string(),
+              })
               .collect::<Vec<_>>()
               .join(", ")
-          )
+          },
+        );
+
+        format!("{target} must be one of: {options}")
+      }
+      ValidationErrorKind::MinLength { limit } => {
+        let count = self
+          .0
+          .instance()
+          .as_str()
+          .map(|value| value.chars().count());
+
+        count.map_or_else(
+          || format!("{target} must be at least {limit} characters long"),
+          |count| {
+            format!(
+              "{target} must be at least {limit} characters long, found {count}"
+            )
+          },
+        )
+      }
+      ValidationErrorKind::Required { property } => {
+        let property = property
+          .as_str()
+          .map_or_else(|| property.to_string(), str::to_string);
+
+        let path = if path.is_empty() {
+          property
+        } else {
+          format!("{path}.{property}")
         };
 
-        if let Some(summary) = Self::summarize_schema_context(context) {
-          format!("{base}: {summary}")
-        } else {
-          base
-        }
+        format!("missing required setting `{path}`")
       }
-      ValidationErrorKind::OneOfNotValid { context } => {
-        format!(
-          "{target} does not match any schema in oneOf{}",
-          Self::summarize_schema_context(context)
-            .map(|msg| format!(": {msg}"))
-            .unwrap_or_default()
-        )
-      }
-      ValidationErrorKind::Pattern { pattern } => {
-        format!("{target} does not match pattern `{pattern}`")
-      }
-      ValidationErrorKind::PropertyNames { error } => {
-        format!(
-          "invalid property name in {target}: {}",
-          Self::format_validation_error(error)
-        )
-      }
-      ValidationErrorKind::UnevaluatedItems { unexpected }
-      | ValidationErrorKind::UnevaluatedProperties { unexpected } => {
-        if unexpected.is_empty() {
-          format!("unevaluated properties are not allowed in {target}")
-        } else {
-          let properties = unexpected.join(", ");
-          format!(
-            "unevaluated properties are not allowed in {target}: {properties}"
-          )
-        }
+      ValidationErrorKind::Type { kind } => {
+        let expected = match kind {
+          TypeKind::Single(type_) => type_.to_string(),
+          TypeKind::Multiple(types) => {
+            let mut types = types
+              .iter()
+              .map(|type_| type_.to_string())
+              .collect::<Vec<_>>();
+
+            types.sort();
+
+            match types.len() {
+              0 => String::new(),
+              1 => types.pop().unwrap(),
+              2 => format!("{} or {}", types[0], types[1]),
+              _ => {
+                let last = types.pop().unwrap();
+                format!("{}, or {last}", types.join(", "))
+              }
+            }
+          }
+        };
+
+        let actual = match self.0.instance().as_ref() {
+          Value::Null => "null".to_string(),
+          Value::Bool(value) => format!("boolean {value}"),
+          Value::Number(value) => {
+            if value.is_i64() || value.is_u64() {
+              format!("integer {value}")
+            } else {
+              format!("number {value}")
+            }
+          }
+          Value::String(value) => format!("string \"{value}\""),
+          Value::Array(value) => format!("array of length {}", value.len()),
+          Value::Object(_) => "object".to_string(),
+        };
+
+        format!("expected {expected} for {target}, got {actual}")
       }
       ValidationErrorKind::UniqueItems => {
         format!("items in {target} must be unique")
       }
-      ValidationErrorKind::Referencing(error) => {
-        format!("schema reference error: {error}")
-      }
+      _ => format!("{target}: {}", self.0.masked()),
     };
 
-    Self::lowercase_message(message)
-  }
-
-  fn join_path_segments(base: &str, segment: &str) -> String {
-    if base.is_empty() {
-      segment.to_string()
-    } else {
-      format!("{base}.{segment}")
-    }
-  }
-
-  fn lowercase_message(message: String) -> String {
     let mut chars = message.chars();
 
     if let Some(first) = chars.next() {
-      let mut lowered = String::with_capacity(message.len());
-      lowered.extend(first.to_lowercase());
-      lowered.push_str(chars.as_str());
-      lowered
+      write!(f, "{}{}", first.to_lowercase(), chars.as_str())
     } else {
-      message
+      f.write_str(&message)
     }
-  }
-
-  fn matched_schema_indexes(
-    context: &[Vec<ValidationError<'_>>],
-  ) -> Vec<usize> {
-    context
-      .iter()
-      .enumerate()
-      .filter_map(|(idx, errors)| {
-        if errors.is_empty() {
-          Some(idx + 1)
-        } else {
-          None
-        }
-      })
-      .collect()
-  }
-
-  fn object_length(value: &Value) -> Option<usize> {
-    value.as_object().map(serde_json::Map::len)
-  }
-
-  fn string_length(value: &Value) -> Option<usize> {
-    value.as_str().map(|string| string.chars().count())
-  }
-
-  fn summarize_schema_context(
-    context: &[Vec<ValidationError<'_>>],
-  ) -> Option<String> {
-    if context.is_empty() {
-      return None;
-    }
-
-    let parts = context
-      .iter()
-      .enumerate()
-      .map(|(idx, errors)| {
-        let label = format!("schema {}", idx + 1);
-
-        if errors.is_empty() {
-          format!("{label}: matched")
-        } else {
-          let message = errors.first().map_or_else(
-            || "did not match".to_string(),
-            Self::format_validation_error,
-          );
-
-          format!("{label}: {message}")
-        }
-      })
-      .collect::<Vec<_>>();
-
-    Some(parts.join("; "))
-  }
-
-  fn value_to_property(property: &Value) -> String {
-    property
-      .as_str()
-      .map_or_else(|| property.to_string(), str::to_string)
   }
 }
 


### PR DESCRIPTION
Simplify schema validation error formatting by retaining targeted messages for common diagnostics and delegating remaining variants to jsonschema's masked formatter.