### PR TITLE
Add project name normalization rule

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1598,13 +1598,32 @@ mod tests {
   }
 
   #[test]
-  fn project_name_may_be_non_normalized() {
+  fn project_name_normalization_is_opt_in() {
     Test::new(indoc! {
       r#"
       [project]
       name = "My_Package"
       version = "1.0.0"
       "#
+    })
+    .run();
+  }
+
+  #[test]
+  fn project_name_normalization_warns_when_enabled() {
+    Test::new(indoc! {
+      r#"
+      [project]
+      name = "My_Package"
+      version = "1.0.0"
+
+      [tool.pyproject.rules]
+      project-name-normalization = "warning"
+      "#
+    })
+    .warning(Message {
+      range: (1, 7, 1, 19),
+      text: "`project.name` is not normalized (use `my-package`)",
     })
     .run();
   }

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -60,6 +60,7 @@ mod project_license_files;
 mod project_license_value;
 mod project_license_value_deprecations;
 mod project_name;
+mod project_name_normalization;
 mod project_optional_dependencies;
 mod project_people;
 mod project_readme;

--- a/src/rule/project_name_normalization.rs
+++ b/src/rule/project_name_normalization.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+define_rule! {
+  ProjectNameNormalizationRule {
+    id: "project-name-normalization",
+    message: "`project.name` is not normalized",
+    default_level: RuleLevel::Off,
+    run(context) {
+      let Some(name) = context.get("project.name") else {
+        return Vec::new();
+      };
+
+      let Some(string) = name.as_str() else {
+        return Vec::new();
+      };
+
+      let value = string.value();
+
+      let Ok(normalized) = PackageName::from_str(value) else {
+        return Vec::new();
+      };
+
+      if value == normalized.as_ref() {
+        Vec::new()
+      } else {
+        vec![Diagnostic::warning(
+          format!("`project.name` is not normalized (use `{normalized}`)"),
+          name.span(context.content()),
+        )]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the opt-in `project-name-normalization` rule.

It is disabled by default and, when enabled, warns for valid non-canonical project names with the canonical spelling to use.

Tests: `cargo test -p pyproject`.