### PR TITLE
Validate `tool.pyproject` configuration

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -337,6 +337,40 @@ mod tests {
     })
     .run();
   }
+
+  #[test]
+  fn json_schema_reports_invalid_pyproject_rule_configuration() {
+    Test::new(indoc! {
+      r#"
+      [tool.pyproject]
+      unknown = true
+
+      [tool.pyproject.rules]
+      unknown = "warning"
+      project-name = "invalid"
+
+      [tool.pyproject.rules.project-version]
+      unknown = "warning"
+      "#
+    })
+    .error(Message {
+      range: (1, 0, 1, 14),
+      text: "unknown setting `tool.pyproject.unknown`",
+    })
+    .error(Message {
+      range: (4, 0, 4, 19),
+      text: "unknown setting `tool.pyproject.rules.unknown`",
+    })
+    .error(Message {
+      range: (5, 0, 5, 24),
+      text: "`tool.pyproject.rules.project-name` must be one of: \"error\", \"hint\", \"information\", \"info\", \"off\", \"warning\"",
+    })
+    .error(Message {
+      range: (8, 0, 8, 19),
+      text: "unknown setting `tool.pyproject.rules.project-version.unknown`",
+    })
+    .run();
+  }
   #[test]
   fn poetry_urls_must_be_a_table() {
     Test::new(indoc! {

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -757,6 +757,14 @@ impl<'a> Completions<'a> {
 
     schema
       .get("enum")
+      .or_else(|| {
+        schema
+          .get("anyOf")
+          .and_then(Value::as_array)
+          .and_then(|schemas| {
+            schemas.iter().find_map(|schema| schema.get("enum"))
+          })
+      })
       .and_then(Value::as_array)
       .map(|values| Self::enum_completions(values, prefix))
       .unwrap_or_default()
@@ -780,6 +788,8 @@ impl<'a> Completions<'a> {
       ("build-system", "PEP 517 build system configuration"),
       ("dependency-groups", "PEP 735 dependency groups"),
       ("tool", "Tool-specific configuration"),
+      ("tool.pyproject", "pyproject configuration"),
+      ("tool.pyproject.rules", "pyproject rule configuration"),
     ];
 
     for (name, description) in sections {
@@ -815,6 +825,16 @@ impl<'a> Completions<'a> {
 
   fn tool_key_completions(prefix: &str) -> Vec<lsp::CompletionItem> {
     let mut items = Vec::new();
+
+    if Self::matches_prefix("pyproject", prefix) {
+      items.push(lsp::CompletionItem {
+        label: "pyproject".to_string(),
+        kind: Some(lsp::CompletionItemKind::PROPERTY),
+        detail: Some("pyproject configuration section".to_string()),
+        insert_text: Some("pyproject".to_string()),
+        ..Default::default()
+      });
+    }
 
     for schema in SCHEMAS {
       if let Some(tool) = schema.tool
@@ -920,6 +940,8 @@ mod tests {
         "tool.pdm",
         "tool.poe",
         "tool.poetry",
+        "tool.pyproject",
+        "tool.pyproject.rules",
         "tool.pyright",
         "tool.pytest",
         "tool.repo-review",
@@ -964,6 +986,8 @@ mod tests {
         "tool.pdm",
         "tool.poe",
         "tool.poetry",
+        "tool.pyproject",
+        "tool.pyproject.rules",
         "tool.pyright",
         "tool.pytest",
         "tool.repo-review",
@@ -1198,6 +1222,7 @@ mod tests {
         "pdm",
         "poe",
         "poetry",
+        "pyproject",
         "pyright",
         "pytest",
         "repo-review",
@@ -1251,6 +1276,51 @@ mod tests {
         "verbose",
         "workers",
       ]
+    );
+  }
+
+  #[test]
+  fn completes_pyproject_rule_configuration() {
+    assert_eq!(
+      completions(
+        indoc! {
+          r"
+          [tool.pyproject.rules]
+          project-na
+          "
+        },
+        1,
+        10,
+      ),
+      vec!["project-name", "project-name-normalization"]
+    );
+
+    assert_eq!(
+      completions(
+        indoc! {
+          r"
+          [tool.pyproject.rules.project-name]
+          le
+          "
+        },
+        1,
+        2,
+      ),
+      vec!["level"]
+    );
+
+    assert_eq!(
+      completions(
+        indoc! {
+          r#"
+          [tool.pyproject.rules]
+          project-name = "w
+          "#
+        },
+        1,
+        17,
+      ),
+      vec!["warning"]
     );
   }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,11 @@ pub(crate) enum RuleLevel {
   Warning,
 }
 
+impl RuleLevel {
+  pub(crate) const VALUES: &[&str] =
+    &["error", "hint", "information", "info", "off", "warning"];
+}
+
 impl From<RuleLevel> for lsp::DiagnosticSeverity {
   fn from(value: RuleLevel) -> Self {
     match value {

--- a/src/schema_error.rs
+++ b/src/schema_error.rs
@@ -48,6 +48,14 @@ impl Display for SchemaError<'_> {
 
         format!("unknown setting {setting}")
       }
+      ValidationErrorKind::AnyOf { context } => context
+        .iter()
+        .flatten()
+        .find(|error| matches!(error.kind(), ValidationErrorKind::Enum { .. }))
+        .map_or_else(
+          || format!("{target} must be a rule level or configuration table"),
+          |error| SchemaError(error).to_string(),
+        ),
       ValidationErrorKind::Enum { options } => {
         let options = options.as_array().map_or_else(
           || options.to_string(),

--- a/src/schema_store.rs
+++ b/src/schema_store.rs
@@ -24,11 +24,49 @@ impl SchemaStore {
     static ROOT: OnceLock<Value> = OnceLock::new();
 
     ROOT.get_or_init(|| {
-      let tool_properties = SCHEMAS
+      let rule_level = json!({ "enum": RuleLevel::VALUES });
+
+      let rule_config = json!({
+        "additionalProperties": false,
+        "properties": {
+          "level": rule_level,
+        },
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": RuleLevel::VALUES,
+          },
+          {
+            "type": "object",
+          },
+        ],
+      });
+
+      let rule_properties = inventory::iter::<&dyn Rule>
+        .into_iter()
+        .map(|rule| (rule.id().to_string(), rule_config.clone()))
+        .collect::<Map<String, Value>>();
+
+      let mut tool_properties = SCHEMAS
         .iter()
         .filter_map(|schema| schema.tool.map(|tool| (tool, schema.url)))
         .map(|(tool, url)| (tool.to_string(), json!({ "$ref": url })))
         .collect::<Map<String, Value>>();
+
+      tool_properties.insert(
+        "pyproject".to_string(),
+        json!({
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "rules": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": rule_properties,
+            },
+          },
+        }),
+      );
 
       json!({
         "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
Fixes #118.

Adds a built-in schema for `[tool.pyproject]` that derives accepted rule IDs from the registered rules. Invalid rule levels and unknown configuration keys now produce diagnostics.

Also adds completions for the configuration tables, rule IDs, `level`, and severity values.

Tests: `cargo test --workspace`; `cargo clippy --workspace --all-targets`.